### PR TITLE
MODELS+API: Admins can now insert purchases with inactive products.

### DIFF
--- a/shopdb/models.py
+++ b/shopdb/models.py
@@ -380,15 +380,6 @@ class Purchase(db.Model):
 
         return user_id
 
-    @validates('product_id')
-    def validate_product(self, key, product_id):
-        """Make sure that the product is active"""
-        product = Product.query.filter(Product.id == product_id).first()
-        if not product or not product.active:
-            raise EntryIsInactive()
-
-        return product_id
-
     @hybrid_method
     def toggle_revoke(self, revoked):
         if self.revoked == revoked:

--- a/shopdb/routes/purchases.py
+++ b/shopdb/routes/purchases.py
@@ -96,8 +96,9 @@ def create_purchase(admin):
     product = Product.query.filter_by(id=data['product_id']).first()
     if not product:
         raise exc.EntryNotFound()
-    if not product.active:
-        raise exc.EntryIsInactive()
+    if not admin:
+        if not product.active:
+            raise exc.EntryIsInactive()
 
     # Check amount
     if data['amount'] <= 0:

--- a/shopdb/routes/purchases.py
+++ b/shopdb/routes/purchases.py
@@ -96,9 +96,8 @@ def create_purchase(admin):
     product = Product.query.filter_by(id=data['product_id']).first()
     if not product:
         raise exc.EntryNotFound()
-    if not admin:
-        if not product.active:
-            raise exc.EntryIsInactive()
+    if not admin and not product.active:
+        raise exc.EntryIsInactive()
 
     # Check amount
     if data['amount'] <= 0:

--- a/tests/test_api_create_purchase.py
+++ b/tests/test_api_create_purchase.py
@@ -121,10 +121,25 @@ class CreatePurchaseAPITestCase(BaseAPITestCase):
         product.active = False
         db.session.commit()
         data = {'user_id': 1, 'product_id': 4, 'amount': 2}
-        res = self.post(url='/purchases', role='admin', data=data)
+        res = self.post(url='/purchases', role='user', data=data)
         self.assertEqual(res.status_code, 401)
         self.assertException(res, exc.EntryIsInactive)
         self.assertEqual(len(Purchase.query.all()), 0)
+
+    def test_create_purchase_inactive_product_by_admin(self):
+        """
+        If the purchase is made by an administrator, the product is allowed
+        to be inactive.
+        """
+        product = Product.query.filter_by(id=4).first()
+        product.active = False
+        db.session.commit()
+        data = {'user_id': 1, 'product_id': 4, 'amount': 2}
+        res = self.post(url='/purchases', role='admin', data=data)
+        self.assertEqual(res.status_code, 200)
+        data = json.loads(res.data)
+        assert 'message' in data
+        self.assertEqual(data['message'], 'Purchase created.')
 
     def test_create_purchase_invalid_amount(self):
         """Create a purchase with an invalid amount."""

--- a/tests/test_model_purchase.py
+++ b/tests/test_model_purchase.py
@@ -11,21 +11,6 @@ import datetime
 
 
 class PurchaseModelTestCase(BaseTestCase):
-    def test_insert_purchase_with_inactive_product(self):
-        """It must be ensured that non-active products cannot be bought."""
-        product = Product.query.filter_by(id=1).first()
-        self.assertTrue(product.active)
-        product.active = False
-        db.session.commit()
-        product = Product.query.filter_by(id=1).first()
-        self.assertFalse(product.active)
-        with self.assertRaises(exc.EntryIsInactive):
-            purchase = Purchase(user_id=1, product_id=1, amount=1)
-        db.session.rollback()
-        # No purchase may have been made at this point
-        purchases = Purchase.query.all()
-        self.assertEqual(len(purchases), 0)
-
     def test_insert_simple_purchase(self):
         """Testing a simple purchase"""
         user = User.query.filter_by(id=1).first()


### PR DESCRIPTION
Since the purchase table has no optional admin_id column, the validation of an active product had to be removed. The API now handles this for users, but allows the insertion of purchases with inactive products for admins. I thought that adding a column to the purchase table is not an option because we would have to migrate the current database agian. Resolves #12  